### PR TITLE
Only use backwards compatible storage if no config

### DIFF
--- a/python/replicate/config.py
+++ b/python/replicate/config.py
@@ -88,7 +88,7 @@ def validate_and_set_defaults(data: Dict[str, Any], project_dir: str) -> Dict[st
     for key in REQUIRED_KEYS:
         if key not in data:
             raise ConfigValidationError(
-                "The option '{}' is required in replicate.yaml, but you have no set it.".format(
+                "The option '{}' is required in replicate.yaml, but you have not set it.".format(
                     key
                 )
             )

--- a/python/tests/test_experiment.py
+++ b/python/tests/test_experiment.py
@@ -183,6 +183,12 @@ def test_deprecated_repository_backwards_compatible(temp_workdir):
     assert isinstance(experiment, Experiment)
     assert experiment._project._repository_url == "file://.replicate/storage"
 
+    with open("replicate.yaml", "w") as f:
+        f.write("repository: file://foobar")
+    experiment = replicate.init()
+    assert isinstance(experiment, Experiment)
+    assert experiment._project._repository_url == "file://foobar"
+
 
 class Blah:
     pass


### PR DESCRIPTION
If .replicate/storage exists, this obliterates replicate.yaml