### PR TITLE
Add Developer Certificate of Origin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,47 @@
 # Contributing guide
 
+## Making a contribution
+
+### Signing your work
+
+Each commit you contribute to Replicate must be signed off. It certifies that you wrote the patch, or have the right to contribute it. It is called the [Developer Certificate of Origin](https://developercertificate.org/) and was originally developed for the Linux kernel.
+
+If you can certify the following:
+
+```
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then add this line to each of your Git commit messages, with your name and email:
+
+```
+Signed-off-by: Joe Smith <joe.smith@email.com>
+```
+
+You can sign your commit automatically by passing the `-s` option to Git commit: `git commit -s -m "Reticulate splines"`
+
 ## Development environment
 
 Run this to install the CLI and Python library locally for development:


### PR DESCRIPTION
I've also added a DCO check using [this DCO probot app](https://probot.github.io/apps/dco/), which adds helpful instructions:

<img width="945" alt="Screen Shot 2020-11-01 at 10 16 19" src="https://user-images.githubusercontent.com/40906/97810803-575fce00-1c2b-11eb-9ff3-9504d723584c.png">
<img width="888" alt="Screen Shot 2020-11-01 at 10 16 30" src="https://user-images.githubusercontent.com/40906/97810805-5a5abe80-1c2b-11eb-8fe2-45d6789f45f4.png">
