### PR TITLE
Remove 32 bit support

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -2,8 +2,8 @@ SHELL := /bin/bash
 
 VERSION := 0.1.43
 ENVIRONMENT := development
-PLATFORMS := darwin linux windows
-ARCHITECTURES := 386 amd64
+PLATFORMS := darwin linux
+ARCHITECTURES := amd64
 GOOS := $(shell go env GOOS)
 GOARCH := $(shell go env GOARCH)
 MAIN := cmd/replicate/main.go

--- a/python/Makefile
+++ b/python/Makefile
@@ -43,7 +43,6 @@ clean:
 .PHONY: build
 build: clean
 	pip install wheel
-	python setup.py bdist_wheel --plat-name manylinux1_i686
 	python setup.py bdist_wheel --plat-name manylinux1_x86_64
 	python setup.py bdist_wheel --plat-name macosx_10_9_x86_64
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,11 +24,9 @@ with open("../README.md", "r", encoding="utf-8") as fh:
 # https://packaging.python.org/specifications/platform-compatibility-tags/
 # https://www.python.org/dev/peps/pep-0425/
 PLAT_NAME_TO_BINARY_PATH = {
-    "linux_i686": "linux/386",
     "linux_x86_64": "linux/amd64",
     # "linux" is the default if no --plat-name is passed, but it is not specific
     # enough for pypi, so we use manylinux for the released version
-    "manylinux1_i686": "linux/386",
     "manylinux1_x86_64": "linux/amd64",
 }
 


### PR DESCRIPTION
Compilation fails / throws warnings because some of our dependencies
don't support 32 bit. This also speeds up build.

Tensorflow and PyTorch don't work on 32 bit. I think it's fairly safe
to say we don't need to support it for now, maybe we can add back in
future if we do.