### PR TITLE
Save repository version at project level

### DIFF
--- a/python/replicate/constants.py
+++ b/python/replicate/constants.py
@@ -2,3 +2,4 @@ WEB_URL = "https://replicate.ai"
 DOCS_URL = WEB_URL + "/docs"
 PYTHON_REFERENCE_DOCS_URL = DOCS_URL + "/reference/python"
 YAML_REFERENCE_DOCS_URL = DOCS_URL + "/reference/yaml"
+REPOSITORY_VERSION = 1

--- a/python/replicate/exceptions.py
+++ b/python/replicate/exceptions.py
@@ -16,7 +16,7 @@ class UnknownRepositoryScheme(Exception):
             + """.
 
 Make sure your repository URL starts with either 'file://', 's3://', or 'gs://'.
-See the docuemntation for more details: {}""".format(
+See the documentation for more details: {}""".format(
                 constants.YAML_REFERENCE_DOCS_URL
             )
         )
@@ -31,4 +31,25 @@ You must either create a replicate.yaml configuration file, or explicitly pass t
 For more information, see {}""".format(
             constants.YAML_REFERENCE_DOCS_URL
         )
+        super().__init__(message)
+
+
+class NewerRepositoryVersion(Exception):
+    def __init__(self, repository_url):
+        message = """The repository at {} is using a newer storage mechanism which is incompatible with your version of Replicate.
+
+To upgrade, run:
+pip install --upgrade replicate
+""".format(
+            repository_url
+        )
+        super().__init__(message)
+
+
+class CorruptedProjectSpec(Exception):
+    def __init__(self, path):
+        message = """The project spec file at {} is corrupted.
+
+You can manually edit it with the format {"version": VERSION},
+where VERSION is an integer."""
         super().__init__(message)

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -3,8 +3,8 @@ import tempfile
 
 import pytest
 
-from replicate.project import get_project_dir
-from replicate.exceptions import ConfigNotFoundError
+from replicate.project import get_project_dir, Project, ProjectSpec
+from replicate.exceptions import ConfigNotFoundError, CorruptedProjectSpec
 
 
 @pytest.fixture
@@ -42,3 +42,80 @@ def test_get_project_dir(temp_workdir_in_subdir):
     # missing replicate.yaml
     with pytest.raises(ConfigNotFoundError):
         get_project_dir()
+
+
+def test_load_project_spec(temp_workdir):
+    with open("replicate.yaml", "w") as f:
+        f.write("repository: file://.replicate/")
+
+    os.mkdir(".replicate")
+    with open(".replicate/repository.json", "w") as f:
+        f.write(
+            """{
+  "version": 1234
+}"""
+        )
+
+    project = Project()
+    assert project._load_project_spec() == ProjectSpec(version=1234)
+
+
+def test_load_missing_project_spec(temp_workdir):
+    with open("replicate.yaml", "w") as f:
+        f.write("repository: file://.replicate/")
+
+    project = Project()
+    assert project._load_project_spec() is None
+
+
+def test_load_corrupted_project_spec(temp_workdir):
+    with open("replicate.yaml", "w") as f:
+        f.write("repository: file://.replicate/")
+
+    project = Project()
+    os.mkdir(".replicate")
+
+    with open(".replicate/repository.json", "w") as f:
+        f.write(
+            """{
+  "version": asdf
+}"""
+        )
+
+    with pytest.raises(CorruptedProjectSpec):
+        project._load_project_spec()
+
+    with open(".replicate/repository.json", "w") as f:
+        f.write(
+            """{
+  "foo": "bar"
+}"""
+        )
+
+    with pytest.raises(CorruptedProjectSpec):
+        project._load_project_spec()
+
+
+def test_write_project_spec(temp_workdir):
+    with open("replicate.yaml", "w") as f:
+        f.write("repository: file://.replicate/")
+
+    project = Project()
+    project._write_project_spec(version=1234)
+
+    with open(".replicate/repository.json") as f:
+        assert (
+            f.read()
+            == """{
+  "version": 1234
+}"""
+        )
+
+
+def test_write_load_project_spec(temp_workdir):
+    with open("replicate.yaml", "w") as f:
+        f.write("repository: file://.replicate/")
+
+    project = Project()
+    project._write_project_spec(version=1234)
+    assert project._load_project_spec().version == 1234


### PR DESCRIPTION
This allows us to upgrade to better storage mechanisms in the
future. A project must use a single consistent repository version.

A file called project.json is written to the top level of the
project's repository. That file is checked on replicate.init(), and if
a newer version is detected, the experiment fails to start.