### PR TITLE
Make targets to verify that Go and Python are installed correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 ENVIRONMENT := development
 
 .PHONY: build
-build:
+build: verify-dev-env
 	cd go && $(MAKE) build-all ENVIRONMENT=$(ENVIRONMENT)
 	cd python && $(MAKE) build
 
 .PHONY: develop
-develop:
+develop: verify-dev-env
 	cd go && $(MAKE) build
 	cd go && $(MAKE) install
 	cd python && python setup.py develop
@@ -58,3 +58,14 @@ release-manual: check-version-var verify-clean-main
 .PHONY: check-version-var
 check-version-var:
 	test $(VERSION)
+
+.PHONY: verify-dev-env
+verify-dev-env: verify-go-version verify-python-version
+
+.PHONY: verify-go-version
+verify-go-version:
+	@./makefile-scripts/verify-go-version.sh
+
+.PHONY: verify-python-version
+verify-python-version:
+	@./makefile-scripts/verify-python-version.sh

--- a/makefile-scripts/verify-go-version.sh
+++ b/makefile-scripts/verify-go-version.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+
+INSTALL_MESSAGE="Please follow the instructions on https://golang.org/doc/install to install the latest version of Go."
+
+GO_VERSION=$(go version 2>&1 || true)
+
+if $(echo "$GO_VERSION" | grep -q -E 'go: (command )?not found'); then
+    echo "ERROR: Go is not installed."
+    echo
+    echo "$INSTALL_MESSAGE"
+    exit 1
+fi
+
+if $(echo "$GO_VERSION" | grep -q -E -v "go version"); then
+    echo "ERROR: failed to determine go version, 'go version' returned:"
+    echo "  $GO_VERSION"
+    echo
+    echo "$INSTALL_MESSAGE"
+    exit 1
+fi
+
+GO_VERSION_NUMBER=$(echo "$GO_VERSION" | sed -E 's/^go version go([^ ]+) .+$/\1/')
+
+if $(echo "$GO_VERSION_NUMBER" | grep -q -E -v '^1\.1[456]'); then
+    echo "ERROR: Unsupported Go version: $GO_VERSION_NUMBER"
+    echo "Replicate requires Go >= 1.14"
+    echo
+    echo "$INSTALL_MESSAGE"
+    exit 1
+fi

--- a/makefile-scripts/verify-python-version.sh
+++ b/makefile-scripts/verify-python-version.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -eu
+
+RECOMMENDED_PYTHON_VERSION="3.8.6"
+INSTALL_MESSAGE="We recommend using pyenv to install Python 3 and pip.
+Follow the instructions on https://github.com/pyenv/pyenv-installer to install pyenv.
+Then install Python 3:
+  $ pyenv install $RECOMMENDED_PYTHON_VERSION
+  $ pyenv local $RECOMMENDED_PYTHON_VERSION
+Or, if you prefer to set the Python version globally:
+  $ pyenv global $RECOMMENDED_PYTHON_VERSION"
+
+PYTHON_VERSION=$(python --version 2>&1 || true)
+
+if $(echo "$PYTHON_VERSION" | grep -q -E 'python: (command )?not found'); then
+    echo "ERROR: Python is not installed."
+    echo
+    echo "$INSTALL_MESSAGE"
+    exit 1
+fi
+
+if $(echo "$PYTHON_VERSION" | grep -q -E -v "^Python "); then
+    echo "ERROR: failed to determine Python version, 'python --version' returned:"
+    echo "  $PYTHON_VERSION"
+    echo
+    echo "$INSTALL_MESSAGE"
+    exit 1
+fi
+
+PYTHON_VERSION_NUMBER=$(echo "$PYTHON_VERSION" | sed -E 's/^Python (.+)$/\1/')
+
+if $(echo "$PYTHON_VERSION_NUMBER" | grep -q -E -v '^3\.[6789]'); then
+    echo "ERROR: Unsupported Python version: $PYTHON_VERSION_NUMBER"
+    echo "Replicate requires Python >= 3.6.0"
+    echo
+    echo "$INSTALL_MESSAGE"
+    exit 1
+fi
+
+PIP_VERSION=$(pip --version 2>&1 || true)
+
+if $(echo "$PIP_VERSION" | grep -q -E 'pip: (command )?not found'); then
+    echo "ERROR: pip is not installed."
+    echo
+    echo "$INSTALL_MESSAGE"
+    exit 1
+fi
+
+if $(echo "$PIP_VERSION" | grep -q -E -v "pip .*python"); then
+    echo "ERROR: failed to determine pip version, 'pip --version' returned:"
+    echo "  $PIP_VERSION"
+    echo
+    echo "$INSTALL_MESSAGE"
+    exit 1
+fi
+
+PIP_PYTHON_VERSION_NUMBER=$(echo "$PIP_VERSION" | sed -E 's/^pip.*\(python (.+)\)$/\1/')
+
+if $(echo "$PIP_PYTHON_VERSION_NUMBER" | grep -q -E -v '^3\.[6789]'); then
+    echo "ERROR: Unsupported Python version in pip: $PIP_PYTHON_VERSION_NUMBER"
+    echo "Replicate requires pip with Python >= 3.6.0"
+    echo
+    echo "$INSTALL_MESSAGE"
+    exit 1
+fi


### PR DESCRIPTION
Run on make build/develop, checks that Go, Python, and pip are all installed on the PATH and at the correct versions.

If not, points to recommended install instructions.