### PR TITLE
Allow checking out individual files and directories

### DIFF
--- a/go/pkg/cli/checkout.go
+++ b/go/pkg/cli/checkout.go
@@ -90,12 +90,7 @@ func getExperimentAndCheckpoint(prefix string, repo repository.Repository) (*pro
 }
 
 // Handle errors related to the outputDir
-func validateOutputDir(outputDir string) error {
-	// FIXME(vastolorde95): If outputPath does not exist, there is no way to distinguish if
-	// it is supposed to be a file or a directory. Should we ask the user for a prompt if
-	// the checkoutPath is a file? This way we will be able to support:
-	//
-	// replicate checkout abc123 -o out/new_model.pth -file data/model.pth
+func validateOrCreateOutputDir(outputDir string) error {
 	exists, err := files.FileExists(outputDir)
 	if err != nil {
 		return err
@@ -175,7 +170,7 @@ func checkoutCheckpoint(opts checkoutOpts, args []string) error {
 		}
 	}
 
-	err = validateOutputDir(outputDir)
+	err = validateOrCreateOutputDir(outputDir)
 	if err != nil {
 		return err
 	}
@@ -269,7 +264,7 @@ func checkoutFileOrDir(outputDir string, checkoutPath string, repo repository.Re
 			return err
 		}
 	} else {
-		console.Info("Copied the files %s from experiment %s to %q", checkoutPath, experiment.ShortID(), filepath.Join(outputDir, experiment.Path))
+		console.Info("Copied the path %s from experiment %s to %q", checkoutPath, experiment.ShortID(), filepath.Join(outputDir, experiment.Path))
 	}
 
 	// Overlay checkpoint on top of experiment
@@ -284,7 +279,7 @@ func checkoutFileOrDir(outputDir string, checkoutPath string, repo repository.Re
 
 			}
 		} else {
-			console.Info("Copied the files %s from checkpoint %s to %q", checkoutPath, checkpoint.ShortID(), filepath.Join(outputDir, checkpoint.Path))
+			console.Info("Copied the path %s from checkpoint %s to %q", checkoutPath, checkpoint.ShortID(), filepath.Join(outputDir, checkpoint.Path))
 		}
 
 	}

--- a/go/pkg/cli/checkout.go
+++ b/go/pkg/cli/checkout.go
@@ -91,8 +91,8 @@ func getExperimentAndCheckpoint(prefix string, repo repository.Repository) (*pro
 
 // Handle errors related to the outputDir
 func validateOutputDir(outputDir string) error {
-	// FIXME(vastolorde95): If outputPath does not exist, there is no way to distinguish if 
-	// it is supposed to be a file or a directory. Should we ask the user for a prompt if 
+	// FIXME(vastolorde95): If outputPath does not exist, there is no way to distinguish if
+	// it is supposed to be a file or a directory. Should we ask the user for a prompt if
 	// the checkoutPath is a file? This way we will be able to support:
 	//
 	// replicate checkout abc123 -o out/new_model.pth -file data/model.pth
@@ -115,7 +115,7 @@ func validateOutputDir(outputDir string) error {
 	if !isDir {
 		return fmt.Errorf("Checkout path %q is not a directory", outputDir)
 	}
-	
+
 	return nil
 }
 

--- a/go/pkg/cli/checkout.go
+++ b/go/pkg/cli/checkout.go
@@ -115,6 +115,8 @@ func validateOutputDir(outputDir string) error {
 	if !isDir {
 		return fmt.Errorf("Checkout path %q is not a directory", outputDir)
 	}
+	
+	return nil
 }
 
 // Prompt user for confirmation if the displayPath already exists

--- a/go/pkg/cli/checkout.go
+++ b/go/pkg/cli/checkout.go
@@ -19,6 +19,7 @@ type checkoutOpts struct {
 	outputDirectory string
 	force           bool
 	repositoryURL   string
+	checkoutPath    string
 }
 
 func newCheckoutCommand() *cobra.Command {
@@ -36,92 +37,71 @@ func newCheckoutCommand() *cobra.Command {
 	addRepositoryURLFlagVar(cmd, &opts.repositoryURL)
 	cmd.Flags().StringVarP(&opts.outputDirectory, "output-directory", "o", "", "Output directory (defaults to working directory or directory with replicate.yaml in it)")
 	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Force checkout without prompt, even if the directory is not empty")
+	cmd.Flags().StringVarP(&opts.checkoutPath, "path", "", "", "A specific file or directory to checkout (defaults to all files or directory in checkpoint/experiment)")
 
 	return cmd
 }
 
-func checkoutCheckpoint(opts checkoutOpts, args []string) error {
-	prefix := args[0]
-
-	outputDir := opts.outputDirectory
-	if outputDir == "" {
-		var err error
-		outputDir, err = getProjectDir()
-		if err != nil {
-			return err
-		}
-	}
-
+// Returns the repository requested by opts.repositoryURL
+func getRepositoryFromOpts(opts checkoutOpts) (repository.Repository, error) {
 	repositoryURL, projectDir, err := getRepositoryURLFromStringOrConfig(opts.repositoryURL)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	repo, err := getRepository(repositoryURL, projectDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	exists, err := files.FileExists(outputDir)
-	if err != nil {
-		return err
-	}
-	if exists {
-		isDir, err := files.IsDir(outputDir)
-		if err != nil {
-			return err
-		}
-		if !isDir {
-			return fmt.Errorf("Checkout path %q is not a directory", outputDir)
-		}
-	} else {
-		if err := os.MkdirAll(outputDir, 0755); err != nil {
-			return fmt.Errorf("Failed to create directory %q: %w", outputDir, err)
-		}
-	}
+	return repo, nil
+}
 
+// Returns the experiment and the most appropriate checkpoint for that experiment.
+func getExperimentAndCheckpoint(prefix string, repo repository.Repository) (*project.Experiment, *project.Checkpoint, error) {
 	proj := project.NewProject(repo)
 	result, err := proj.CheckpointOrExperimentFromPrefix(prefix)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-
 	experiment := result.Experiment
 	checkpoint := result.Checkpoint
 
 	if checkpoint != nil {
 		console.Info("Checking out files from checkpoint %s and its experiment %s", checkpoint.ShortID(), experiment.ShortID())
-	} else {
-		// When checking out experiment, also check out best/latest checkpoint
-		checkpoint = experiment.BestCheckpoint()
-		if checkpoint != nil {
-			console.Info("Checking out files from experiment %s and its best checkpoint %s", experiment.ShortID(), checkpoint.ShortID())
-		} else {
-			checkpoint = experiment.LatestCheckpoint()
-			if checkpoint != nil {
-				console.Info("Checking out files from experiment %s and its latest checkpoint %s", experiment.ShortID(), checkpoint.ShortID())
-			} else {
-				console.Info("Checking out files from experiment %s", experiment.ShortID())
-			}
-		}
+		return experiment, checkpoint, nil
 	}
 
-	displayPath := filepath.Join(outputDir, experiment.Path)
-
-	// FIXME(bfirsh): this is a bodge and isn't always quite right -- if no experiment path set, and we're checking out checkpoint, display the checkpoint path
-	if experiment.Path == "" && checkpoint != nil {
-		displayPath = filepath.Join(outputDir, checkpoint.Path)
+	// When checking out experiment, also check out best/latest checkpoint
+	checkpoint = experiment.BestCheckpoint()
+	if checkpoint != nil {
+		console.Info("Checking out files from experiment %s and its best checkpoint %s", experiment.ShortID(), checkpoint.ShortID())
+		return experiment, checkpoint, nil
 	}
 
-	exists, err = files.FileExists(displayPath)
+	checkpoint = experiment.LatestCheckpoint()
+	if checkpoint != nil {
+		console.Info("Checking out files from experiment %s and its latest checkpoint %s", experiment.ShortID(), checkpoint.ShortID())
+		return experiment, checkpoint, nil
+	}
+
+	console.Info("Checking out files from experiment %s", experiment.ShortID())
+	return experiment, checkpoint, nil
+}
+
+// Prompt user for confirmation if the diplsayPath already exists
+func overwriteDisplayPathPrompt(displayPath string, force bool) error {
+	exists, err := files.FileExists(displayPath)
 	if err != nil {
 		return err
 	}
+
 	if exists {
 		isEmpty, err := files.DirIsEmpty(displayPath)
 		if err != nil {
 			return err
 		}
-		if !isEmpty && !opts.force {
+		if !isEmpty && !force {
 			console.Warn("The directory %q is not empty.", displayPath)
 			console.Warn("%s Make sure they're saved in Git or Replicate so they're safe!", aurora.Bold("This checkout may overwrite existing files."))
 			fmt.Println()
@@ -139,9 +119,79 @@ func checkoutCheckpoint(opts checkoutOpts, args []string) error {
 			}
 		}
 	}
+	return nil
+}
+
+// replicate CLI `checkout` command
+func checkoutCheckpoint(opts checkoutOpts, args []string) error {
+	prefix := args[0]
+
+	repo, err := getRepositoryFromOpts(opts)
+	if err != nil {
+		return err
+	}
+
+	experiment, checkpoint, err := getExperimentAndCheckpoint(prefix, repo)
+	if err != nil {
+		return err
+	}
+
+	outputDir := opts.outputDirectory
+	if outputDir == "" {
+		var err error
+		outputDir, err = getProjectDir()
+		if err != nil {
+			return err
+		}
+	}
+
+	// TODO(adipal): There is no way to distinguish if the outputPath is a file or
+	// a directory. Ask the user for a prompt if the checkoutPath is a file?
+	exists, err := files.FileExists(outputDir)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("Failed to create directory %q: %w", outputDir, err)
+		}
+	}
+
+	isDir, err := files.IsDir(outputDir)
+	if err != nil {
+		return err
+	}
+
+	if !isDir {
+		return fmt.Errorf("Checkout path %q is not a directory", outputDir)
+	}
+
+	displayPath := filepath.Join(outputDir, experiment.Path)
+
+	// FIXME(bfirsh): this is a bodge and isn't always quite right -- if no experiment path set, and we're checking out checkpoint, display the checkpoint path
+	if experiment.Path == "" && checkpoint != nil {
+		displayPath = filepath.Join(outputDir, checkpoint.Path)
+	}
+
+	err = overwriteDisplayPathPrompt(displayPath, opts.force)
+	if err != nil {
+		return err
+	}
 
 	fmt.Fprintln(os.Stderr)
 
+	checkoutPath := opts.checkoutPath
+	if checkoutPath == "" {
+		return checkoutEntireCheckpoint(outputDir, repo, experiment, checkpoint)
+	} else {
+		return checkoutFileOrDir(outputDir, checkoutPath, repo, experiment, checkpoint)
+	}
+}
+
+// checkout all the files from an experiment or checkpoint
+func checkoutEntireCheckpoint(outputDir string, repo repository.Repository, experiment *project.Experiment, checkpoint *project.Checkpoint) error {
+	// Extract the tarfile
 	experimentFilesExist := true
 	checkpointFilesExist := true
 
@@ -188,4 +238,57 @@ func checkoutCheckpoint(opts checkoutOpts, args []string) error {
 `)
 
 	return nil
+
+}
+
+// checkout all the files from an experiment or checkpoint
+func checkoutFileOrDir(outputDir string, checkoutPath string, repo repository.Repository, experiment *project.Experiment, checkpoint *project.Checkpoint) error {
+	// Extract the tarfile
+	experimentFilesExist := true
+	checkpointFilesExist := true
+
+	if err := repo.GetPathItemTar(path.Join("experiments", experiment.ID+".tar.gz"), checkoutPath, outputDir); err != nil {
+		// Ignore does not exist errors
+		if _, ok := err.(*repository.DoesNotExistError); ok {
+			console.Debug("No experiment data found")
+			experimentFilesExist = false
+		} else {
+			return err
+		}
+	} else {
+		console.Info("Copied the files from experiment %s to %q", experiment.ShortID(), filepath.Join(outputDir, experiment.Path))
+	}
+
+	// Overlay checkpoint on top of experiment
+	if checkpoint != nil {
+
+		if err := repo.GetPathItemTar(path.Join("checkpoints", checkpoint.ID+".tar.gz"), checkoutPath, outputDir); err != nil {
+			if _, ok := err.(*repository.DoesNotExistError); ok {
+				console.Debug("No checkpoint data found")
+				checkpointFilesExist = false
+			} else {
+				return err
+
+			}
+		} else {
+			console.Info("Copied the files from checkpoint %s to %q", checkpoint.ShortID(), filepath.Join(outputDir, checkpoint.Path))
+		}
+
+	}
+
+	if !experimentFilesExist && !checkpointFilesExist {
+		// Just an experiment, no checkpoints
+		if checkpoint == nil {
+			return fmt.Errorf("The experiment %s does not have any files associated with it. You need to pass the 'path' argument to 'init()' to check out files.", experiment.ShortID())
+		}
+		return fmt.Errorf("Neither the experiment %s nor the checkpoint %s has any files associated with it. You need to pass the 'path' argument to 'init()' or 'checkpoint()' to check out files.", experiment.ShortID(), checkpoint.ShortID())
+	}
+
+	console.Info(`If you want to run this experiment again, this is how it was run:
+
+  ` + experiment.Command + `
+`)
+
+	return nil
+
 }

--- a/go/pkg/cli/checkout_test.go
+++ b/go/pkg/cli/checkout_test.go
@@ -68,6 +68,7 @@ func TestCheckout(t *testing.T) {
 	// checkout to output directory
 	err = checkoutCheckpoint(checkoutOpts{
 		outputDirectory: outputDir,
+		checkoutPath:    "",
 		force:           true,
 		repositoryURL:   "file://" + repoDir,
 	}, []string{"1cc"})
@@ -83,7 +84,7 @@ func TestCheckout(t *testing.T) {
 
 	outputDir2, err := files.TempDir("test-checkout-output-2")
 	require.NoError(t, err)
-	defer os.RemoveAll(outputDir)
+	defer os.RemoveAll(outputDir2)
 
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
@@ -93,6 +94,7 @@ func TestCheckout(t *testing.T) {
 	// checkout to working directory without replicate.yaml
 	err = checkoutCheckpoint(checkoutOpts{
 		outputDirectory: "",
+		checkoutPath:    "",
 		force:           true,
 		repositoryURL:   "file://" + repoDir,
 	}, []string{"1cc"})
@@ -105,6 +107,7 @@ func TestCheckout(t *testing.T) {
 	// checkout to working directory with replicate.yaml
 	err = checkoutCheckpoint(checkoutOpts{
 		outputDirectory: "",
+		checkoutPath:    "",
 		force:           true,
 		repositoryURL:   "",
 	}, []string{"1cc"})
@@ -116,6 +119,27 @@ func TestCheckout(t *testing.T) {
 	require.Equal(t, rand1, string(contents))
 
 	contents, err = ioutil.ReadFile(path.Join(outputDir2, rand2))
+	require.NoError(t, err)
+	require.Equal(t, rand2, string(contents))
+
+	outputDir3, err := files.TempDir("test-checkout-output-3")
+	require.NoError(t, err)
+	defer os.RemoveAll(outputDir3)
+
+	// checkout a single file to output directory
+	err = checkoutCheckpoint(checkoutOpts{
+		outputDirectory: outputDir3,
+		checkoutPath:    rand2,
+		force:           true,
+		repositoryURL:   "file://" + repoDir,
+	}, []string{"1cc"})
+	require.NoError(t, err)
+
+	_, err = ioutil.ReadFile(path.Join(outputDir3, rand1))
+	// only checking out rand2, should error
+	require.Error(t, err)
+
+	contents, err = ioutil.ReadFile(path.Join(outputDir3, rand2))
 	require.NoError(t, err)
 	require.Equal(t, rand2, string(contents))
 }

--- a/go/pkg/repository/cached.go
+++ b/go/pkg/repository/cached.go
@@ -74,6 +74,13 @@ func (s *CachedRepository) GetPathTar(tarPath, localPath string) error {
 	return s.repository.GetPathTar(tarPath, localPath)
 }
 
+func (s *CachedRepository) GetPathItemTar(tarPath, itemPath, localPath string) error {
+	if strings.HasPrefix(tarPath, s.cachePrefix) {
+		return s.cacheRepository.GetPathTar(tarPath, localPath)
+	}
+	return s.repository.GetPathItemTar(tarPath, itemPath, localPath)
+}
+
 func (s *CachedRepository) PutPath(localPath string, repoPath string) error {
 	// FIXME: potential for cache and remote to get out of sync on error
 	if strings.HasPrefix(repoPath, s.cachePrefix) {

--- a/go/pkg/repository/cached.go
+++ b/go/pkg/repository/cached.go
@@ -109,6 +109,13 @@ func (s *CachedRepository) List(p string) ([]string, error) {
 	return s.repository.List(p)
 }
 
+func (s *CachedRepository) ListTarFile(p string) ([]string, error) {
+	if strings.HasPrefix(p, s.cachePrefix) {
+		return s.cacheRepository.List(p)
+	}
+	return s.repository.ListTarFile(p)
+}
+
 func (s *CachedRepository) ListRecursive(results chan<- ListResult, path string) {
 	if strings.HasPrefix(path, s.cachePrefix) {
 		s.cacheRepository.ListRecursive(results, path)

--- a/go/pkg/repository/disk.go
+++ b/go/pkg/repository/disk.go
@@ -162,6 +162,29 @@ func (s *DiskRepository) List(p string) ([]string, error) {
 	return result, nil
 }
 
+func (s *DiskRepository) ListTarFile(tarPath string) ([]string, error) {
+	fullTarPath := path.Join(s.rootDir, tarPath)
+	exists, err := files.FileExists(fullTarPath)
+	if err != nil {
+		return []string{}, err
+	}
+	if !exists {
+		return []string{}, &DoesNotExistError{msg: "ListTarFile: does not exist: " + fullTarPath}
+	}
+
+	files, err := getListOfFilesInTar(fullTarPath)
+	if err != nil {
+		return []string{}, err
+	}
+
+	tarname := filepath.Base(strings.TrimSuffix(tarPath, ".tar.gz"))
+	for idx := range files {
+		files[idx] = strings.TrimPrefix(files[idx], tarname+"/")
+	}
+
+	return files, nil
+}
+
 func (s *DiskRepository) ListRecursive(results chan<- ListResult, folder string) {
 	err := filepath.Walk(path.Join(s.rootDir, folder), func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/go/pkg/repository/disk.go
+++ b/go/pkg/repository/disk.go
@@ -166,15 +166,15 @@ func (s *DiskRepository) ListTarFile(tarPath string) ([]string, error) {
 	fullTarPath := path.Join(s.rootDir, tarPath)
 	exists, err := files.FileExists(fullTarPath)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 	if !exists {
-		return []string{}, &DoesNotExistError{msg: "ListTarFile: does not exist: " + fullTarPath}
+		return nil, &DoesNotExistError{msg: "Path does not exist: " + fullTarPath}
 	}
 
 	files, err := getListOfFilesInTar(fullTarPath)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 
 	tarname := filepath.Base(strings.TrimSuffix(tarPath, ".tar.gz"))

--- a/go/pkg/repository/disk.go
+++ b/go/pkg/repository/disk.go
@@ -61,6 +61,18 @@ func (s *DiskRepository) GetPathTar(tarPath, localPath string) error {
 	return extractTar(fullTarPath, localPath)
 }
 
+func (s *DiskRepository) GetPathItemTar(tarPath, itemPath, localPath string) error {
+	fullTarPath := path.Join(s.rootDir, tarPath)
+	exists, err := files.FileExists(fullTarPath)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return &DoesNotExistError{msg: "GetPathItemTar: does not exist: " + fullTarPath}
+	}
+	return extractTarItem(fullTarPath, itemPath, localPath)
+}
+
 // Put data at path
 func (s *DiskRepository) Put(p string, data []byte) error {
 	fullPath := path.Join(s.rootDir, p)

--- a/go/pkg/repository/disk_test.go
+++ b/go/pkg/repository/disk_test.go
@@ -88,7 +88,7 @@ func TestDiskGetPathItemTar(t *testing.T) {
 	err = repository.GetPathItemTar("temp.tar.gz", "a.txt", tmpDir)
 	require.NoError(t, err)
 
-	content, err := ioutil.ReadFile(path.Join(tmpDir, "temp/a.txt"))
+	content, err := ioutil.ReadFile(path.Join(tmpDir, "a.txt"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("file a"), content)
 
@@ -96,7 +96,7 @@ func TestDiskGetPathItemTar(t *testing.T) {
 	err = repository.GetPathItemTar("temp.tar.gz", "c", tmpDir)
 	require.NoError(t, err)
 
-	content, err = ioutil.ReadFile(path.Join(tmpDir, "temp/c/d.txt"))
+	content, err = ioutil.ReadFile(path.Join(tmpDir, "c/d.txt"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("file d"), content)
 

--- a/go/pkg/repository/disk_test.go
+++ b/go/pkg/repository/disk_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -154,23 +153,6 @@ func TestDiskRepositoryList(t *testing.T) {
 	require.Equal(t, []string{}, paths)
 }
 
-type Alphabetic []string
-
-func (list Alphabetic) Len() int { return len(list) }
-
-func (list Alphabetic) Swap(i, j int) { list[i], list[j] = list[j], list[i] }
-
-func (list Alphabetic) Less(i, j int) bool {
-	var si string = list[i]
-	var sj string = list[j]
-	var si_lower = strings.ToLower(si)
-	var sj_lower = strings.ToLower(sj)
-	if si_lower == sj_lower {
-		return si < sj
-	}
-	return si_lower < sj_lower
-}
-
 func TestDiskRepositoryListTarFile(t *testing.T) {
 	dir, err := ioutil.TempDir("", "replicate-test")
 	require.NoError(t, err)
@@ -206,7 +188,7 @@ func TestDiskRepositoryListTarFile(t *testing.T) {
 	require.NoError(t, err)
 
 	paths, err := repository.ListTarFile("temp.tar.gz")
-	sort.Sort(Alphabetic(paths))
+	sort.Strings(paths)
 
 	require.NoError(t, err)
 	require.Equal(t, []string{"a.txt", "b.txt", "c/d.txt"}, paths)

--- a/go/pkg/repository/gcs.go
+++ b/go/pkg/repository/gcs.go
@@ -218,19 +218,19 @@ func (s *GCSRepository) ListTarFile(tarPath string) ([]string, error) {
 	// TODO: make a better tar implementation
 	tmpdir, err := files.TempDir("tar")
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 	defer os.RemoveAll(tmpdir)
 	tmptarball := filepath.Join(tmpdir, filepath.Base(tarPath))
 	if err := s.GetPath(tarPath, tmptarball); err != nil {
-		return []string{}, err
+		return nil, err
 	}
 	exists, err := files.FileExists(tmptarball)
 	if err != nil {
 		return []string{}, err
 	}
 	if !exists {
-		return []string{}, &DoesNotExistError{msg: "GetPathTar: does not exist: " + tmptarball}
+		return nil, &DoesNotExistError{msg: "Path does not exist: " + tmptarball}
 	}
 
 	files, err := getListOfFilesInTar(tmptarball)

--- a/go/pkg/repository/gcs.go
+++ b/go/pkg/repository/gcs.go
@@ -213,6 +213,39 @@ func (s *GCSRepository) List(dir string) ([]string, error) {
 	return results, nil
 }
 
+func (s *GCSRepository) ListTarFile(tarPath string) ([]string, error) {
+	// archiver doesn't let us use readers, so download to temporary file
+	// TODO: make a better tar implementation
+	tmpdir, err := files.TempDir("tar")
+	if err != nil {
+		return []string{}, err
+	}
+	defer os.RemoveAll(tmpdir)
+	tmptarball := filepath.Join(tmpdir, filepath.Base(tarPath))
+	if err := s.GetPath(tarPath, tmptarball); err != nil {
+		return []string{}, err
+	}
+	exists, err := files.FileExists(tmptarball)
+	if err != nil {
+		return []string{}, err
+	}
+	if !exists {
+		return []string{}, &DoesNotExistError{msg: "GetPathTar: does not exist: " + tmptarball}
+	}
+
+	files, err := getListOfFilesInTar(tmptarball)
+	if err != nil {
+		return []string{}, err
+	}
+
+	tarname := filepath.Base(strings.TrimSuffix(tarPath, ".tar.gz"))
+	for idx := range files {
+		files[idx] = strings.TrimPrefix(files[idx], tarname+"/")
+	}
+
+	return files, nil
+}
+
 // List files in a path recursively
 func (s *GCSRepository) ListRecursive(results chan<- ListResult, dir string) {
 	s.listRecursive(results, dir, func(_ string) bool { return true })

--- a/go/pkg/repository/gcs.go
+++ b/go/pkg/repository/gcs.go
@@ -324,6 +324,28 @@ func (s *GCSRepository) GetPathTar(tarPath, localPath string) error {
 	return extractTar(tmptarball, localPath)
 }
 
+func (s *GCSRepository) GetPathItemTar(tarPath, itemPath, localPath string) error {
+	// archiver doesn't let us use readers, so download to temporary file
+	// TODO: make a better tar implementation
+	tmpdir, err := files.TempDir("tar")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpdir)
+	tmptarball := filepath.Join(tmpdir, filepath.Base(tarPath))
+	if err := s.GetPath(tarPath, tmptarball); err != nil {
+		return err
+	}
+	exists, err := files.FileExists(tmptarball)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return &DoesNotExistError{msg: "GetPathTar: does not exist: " + tmptarball}
+	}
+	return extractTarItem(tmptarball, itemPath, localPath)
+}
+
 func (s *GCSRepository) bucketExists() (bool, error) {
 	bucket := s.client.Bucket(s.bucketName)
 	_, err := bucket.Attrs(context.TODO())

--- a/go/pkg/repository/repository.go
+++ b/go/pkg/repository/repository.go
@@ -84,6 +84,12 @@ type Repository interface {
 	// If path does not exist, an empty list will be returned.
 	List(path string) ([]string, error)
 
+	// List files in a tar-file
+	//
+	// Returns a list of paths, present inside the give tarfile, that can be passed straight to GetPathItemTar()
+	// Directories are not listed.
+	ListTarFile(path string) ([]string, error)
+
 	// List files in a path recursively
 	ListRecursive(results chan<- ListResult, folder string)
 

--- a/go/pkg/repository/repository.go
+++ b/go/pkg/repository/repository.go
@@ -290,11 +290,7 @@ func extractTarItem(tarPath, itemPath, localPath string) error {
 	if err != nil {
 		return err
 	}
-
-	err = os.Chmod(tmpDir, 0777)
-	if err != nil {
-		return err
-	}
+	defer os.RemoveAll(tmpDir)
 
 	tar := archiver.NewTarGz()
 	tar.StripComponents = 1
@@ -342,7 +338,6 @@ func extractTarItem(tarPath, itemPath, localPath string) error {
 		return err
 	}
 
-	os.RemoveAll(tmpDir)
 	return nil
 }
 

--- a/go/pkg/repository/repository_test.go
+++ b/go/pkg/repository/repository_test.go
@@ -134,7 +134,7 @@ func TestExtractTarItem(t *testing.T) {
 	err = extractTarItem(path.Join(dir, "temp.tar.gz"), "a.txt", tmpDir)
 	require.NoError(t, err)
 
-	content, err := ioutil.ReadFile(path.Join(tmpDir, "temp/a.txt"))
+	content, err := ioutil.ReadFile(path.Join(tmpDir, "a.txt"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("file a"), content)
 
@@ -142,7 +142,7 @@ func TestExtractTarItem(t *testing.T) {
 	err = extractTarItem(path.Join(dir, "temp.tar.gz"), "c", tmpDir)
 	require.NoError(t, err)
 
-	content, err = ioutil.ReadFile(path.Join(tmpDir, "temp/c/d.txt"))
+	content, err = ioutil.ReadFile(path.Join(tmpDir, "c/d.txt"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("file d"), content)
 

--- a/go/pkg/repository/s3.go
+++ b/go/pkg/repository/s3.go
@@ -273,7 +273,7 @@ func (s *S3Repository) GetPathItemTar(tarPath, itemPath, localPath string) error
 		return err
 	}
 	if !exists {
-		return &DoesNotExistError{msg: "GetPathTar: does not exist: " + tmptarball}
+		return &DoesNotExistError{msg: "Path does not exist: " + tmptarball}
 	}
 	return extractTarItem(tmptarball, itemPath, localPath)
 }
@@ -322,24 +322,24 @@ func (s *S3Repository) ListTarFile(tarPath string) ([]string, error) {
 	// TODO: make a better tar implementation
 	tmpdir, err := files.TempDir("tar")
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 	defer os.RemoveAll(tmpdir)
 	tmptarball := filepath.Join(tmpdir, filepath.Base(tarPath))
 	if err := s.GetPath(tarPath, tmptarball); err != nil {
-		return []string{}, err
+		return nil, err
 	}
 	exists, err := files.FileExists(tmptarball)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 	if !exists {
-		return []string{}, &DoesNotExistError{msg: "ListTarFile: does not exist: " + tmptarball}
+		return nil, &DoesNotExistError{msg: "Path does not exist: " + tmptarball}
 	}
 
 	files, err := getListOfFilesInTar(tmptarball)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 
 	tarname := filepath.Base(strings.TrimSuffix(tarPath, ".tar.gz"))

--- a/web/pages/docs/reference/cli.mdx
+++ b/web/pages/docs/reference/cli.mdx
@@ -71,6 +71,7 @@ replicate checkout <experiment or checkpoint ID> [flags]
   -f, --force                     Force checkout without prompt, even if the directory is not empty
   -h, --help                      help for checkout
   -o, --output-directory string   Output directory (defaults to working directory or directory with replicate.yaml in it)
+      --path string               A specific file or directory to checkout (defaults to all files or directory in checkpoint/experiment)
   -R, --repository string         Repository URL (e.g. 's3://my-replicate-bucket' (if omitted, uses repository URL from replicate.yaml)
 
       --color                      Display color in output (default true)


### PR DESCRIPTION
Issue #358 

There are some design decisions to make, so I thought let's discuss them first before implementing a complete solution in subsequent commits.

- I have created a new method in the Repository interface - `GetPathItemTar()` - that allows the user to specify which file/directory they want to extract from the tar ball. This method will be called from `checkoutCheckpoint()` in `checkout.go`

- The solution revolves around using `TarGz.Extract(source, target, destination)`. However, it looks like if the `target` does not exist inside the tar, `Extract` does not throw errors. So I added some code to handle that case.

- Since all files in the tarball are prefixed with the tar file's name, argument `target` in `Extract()` must also contain that prefix, else it will fail to locate the file in the tar. However, I think this detail should be abstracted away from the user and thus `extractTarItem()` in `repository.go` adds the tar file's name as a prefix automatically.

If this is the way to go, I believe I will have to modify the rest of the repository types under go/pkg/repository/ and pkg/cli/checkout.go?

Signed-off-by: Aditya Paliwal <adityapaliwal95@gmail.com>