### PR TITLE
Fix S3 buckets getting left over in tests

### DIFF
--- a/end-to-end-test/conftest.py
+++ b/end-to-end-test/conftest.py
@@ -14,7 +14,7 @@ class TempBucketFactory:
         self.gs_bucket_names = []
 
     def make_name(self):
-        return "replicate-test-" + "".join(
+        return "replicate-test-endtoend-" + "".join(
             random.choice(string.ascii_lowercase) for _ in range(20)
         )
 

--- a/python/tests/repository/test_s3_repository.py
+++ b/python/tests/repository/test_s3_repository.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.external
 
 @pytest.fixture(scope="function")
 def temp_bucket():
-    bucket_name = "replicate-test-" + random_hash()[:20]
+    bucket_name = "replicate-test-unit-" + random_hash()[:20]
 
     yield bucket_name
 

--- a/python/tests/repository/test_s3_repository.py
+++ b/python/tests/repository/test_s3_repository.py
@@ -35,7 +35,9 @@ def test_s3_experiment(temp_bucket, tmpdir):
     current_workdir = os.getcwd()
     try:
         os.chdir(tmpdir)
-        experiment = replicate.init(path=".", params={"foo": "bar"})
+        experiment = replicate.init(
+            path=".", params={"foo": "bar"}, disable_heartbeat=True
+        )
         checkpoint = experiment.checkpoint(
             path=".", step=10, metrics={"loss": 1.1, "baz": "qux"}
         )


### PR DESCRIPTION
The problem was heartbeats were running, and the heartbeat recreated the bucket after the test deleted it. I've also included a couple of other improvements, deets in comments.z