### PR TITLE
Push to website branch on release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ release: check-version-var verify-clean-main bump-version
 	git tag "v$(VERSION)"
 	git push git@github.com:replicate/replicate.git main
 	git push git@github.com:replicate/replicate.git main --tags
+	git push git@github.com:replicate/replicate.git main:website --force
 
 .PHONY: verify-version
 # quick and dirty


### PR DESCRIPTION
## Why

We want to update website on release so docs represent released version, but also allow us to change website between releases.

## How

https://replicate.ai is now deployed from the `website` branch. On release, push to this branch. If we want to do hotfixes for the website, we can cherry-pick from `main` to the `website` branch.

For simplicity, release force pushes to `website` and will blow away any hot fixes. We'll have to be disciplined and make sure we always cherry-pick from `main`.

This is intended as a really lightweight "release" branch sort of thing. We could do more complex things (merging changes instead of blowing away hotfixes, documentation versioning, etc) but this seemed like the simplest thing that achieves what we want.

Note: I haven't actually tested this, so we'll need to remember to check this works on next release. 🤠 