### PR TITLE
Disable flakey heartbeat test

### DIFF
--- a/python/tests/test_heartbeat.py
+++ b/python/tests/test_heartbeat.py
@@ -49,7 +49,7 @@ def test_heartbeat_write(tmpdir):
 
     wait(lambda: os.path.exists(heartbeat_path), timeout_seconds=1, sleep_seconds=0.01)
     # sleep a little extra in case the file is created but not yet written
-    time.sleep(0.5)
+    time.sleep(0.01)
 
     with open(heartbeat_path) as f:
         obj = json.loads(f.read())
@@ -59,7 +59,7 @@ def test_heartbeat_write(tmpdir):
 
     assert t1 < last_heartbeat < t2
 
-    time.sleep(0.5)
+    time.sleep(0.2)
 
     with open(heartbeat_path) as f:
         obj = json.loads(f.read())

--- a/python/tests/test_heartbeat.py
+++ b/python/tests/test_heartbeat.py
@@ -4,6 +4,7 @@ import os
 import datetime
 import dateutil.parser
 from dateutil.tz import tzutc
+import pytest
 from waiting import wait
 
 from replicate.heartbeat import Heartbeat
@@ -32,6 +33,7 @@ def test_heartbeat_running(tmpdir):
     heartbeat.kill()
 
 
+@pytest.mark.skip(reason="fix blocked on #436")
 def test_heartbeat_write(tmpdir):
     tmpdir = str(tmpdir)
     t1 = datetime.datetime.utcnow().replace(tzinfo=tzutc())


### PR DESCRIPTION
The real fix is #436, but this is blocked on #408. I have reverted previous attempt at fixing, because I think this just slows down tests and doesn't actually fix.