### PR TITLE
Auto-increment step number in checkpoint

### DIFF
--- a/python/replicate/experiment.py
+++ b/python/replicate/experiment.py
@@ -503,9 +503,7 @@ class ExperimentCollection:
             else:
                 console.info(
                     "Creating experiment {}: copying '{}' to '{}'...".format(
-                        experiment.short_id(),
-                        experiment.path,
-                        root_url,
+                        experiment.short_id(), experiment.path, root_url,
                     )
                 )
 

--- a/python/replicate/experiment.py
+++ b/python/replicate/experiment.py
@@ -82,6 +82,7 @@ class Experiment:
     def __post_init__(self, project: "Project"):
         self._project = project
         self._heartbeat = None
+        self._step = -1
 
     def short_id(self):
         return self.id[:7]
@@ -136,6 +137,12 @@ class Experiment:
                     "name": primary_metric[0],
                     "goal": primary_metric[1],
                 }
+
+        # Auto-increment step if not provided
+        if step is None:
+            step = self._step + 1
+        # Remember the current step
+        self._step = step
 
         checkpoint = Checkpoint(
             id=random_hash(),
@@ -496,7 +503,9 @@ class ExperimentCollection:
             else:
                 console.info(
                     "Creating experiment {}: copying '{}' to '{}'...".format(
-                        experiment.short_id(), experiment.path, root_url,
+                        experiment.short_id(),
+                        experiment.path,
+                        root_url,
                     )
                 )
 

--- a/python/tests/test_experiment.py
+++ b/python/tests/test_experiment.py
@@ -339,6 +339,24 @@ class TestExperiment:
         assert experiment.checkpoints[0].id == chk1.id
         assert experiment.checkpoints[1].id == chk2.id
 
+    def test_checkpoint_auto_increments_steps(self, temp_workdir):
+        project = Project()
+
+        with open("replicate.yaml", "w") as f:
+            f.write("repository: file://.replicate/")
+
+        experiment = project.experiments.create(
+            path=None, params={"foo": "bar"}, disable_heartbeat=True
+        )
+        chk1 = experiment.checkpoint()
+        chk2 = experiment.checkpoint()
+        chk3 = experiment.checkpoint(step=10)
+        chk4 = experiment.checkpoint()
+        assert chk1.step == 0
+        assert chk2.step == 1
+        assert chk3.step == 10
+        assert chk4.step == 11
+
     def test_delete(self, temp_workdir):
         project = Project()
 

--- a/python/tests/test_experiment.py
+++ b/python/tests/test_experiment.py
@@ -339,7 +339,7 @@ class TestExperiment:
         assert experiment.checkpoints[0].id == chk1.id
         assert experiment.checkpoints[1].id == chk2.id
 
-    def test_checkpoint_auto_increments_steps(self, temp_workdir):
+    def test_checkpoint_auto_increments_step(self, temp_workdir):
         project = Project()
 
         with open("replicate.yaml", "w") as f:


### PR DESCRIPTION
`checkpoint()` now auto-increments the step number if the `step` argument is not provided.

Fixes #276, fixes #296

Signed-off-by: justinchuby <justinchuby@users.noreply.github.com>