### PR TITLE
Copy files before background upload

### DIFF
--- a/go/pkg/cli/daemon.go
+++ b/go/pkg/cli/daemon.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/replicate/replicate/go/pkg/console"
+	"github.com/replicate/replicate/go/pkg/global"
 	"github.com/replicate/replicate/go/pkg/project"
 	"github.com/replicate/replicate/go/pkg/shared"
 )
@@ -19,6 +21,10 @@ func NewDaemonCommand() *cobra.Command {
 
 func runDaemon(cmd *cobra.Command, args []string) error {
 	socketPath := args[0]
+
+	if global.Verbose {
+		console.SetLevel(console.DebugLevel)
+	}
 
 	projectGetter := func() (proj *project.Project, err error) {
 		repositoryURL, projectDir, err := getRepositoryURLFromFlagOrConfig(cmd)

--- a/go/pkg/files/files.go
+++ b/go/pkg/files/files.go
@@ -57,3 +57,14 @@ func DirIsEmpty(dirPath string) (bool, error) {
 	}
 	return false, nil
 }
+
+func CopyFile(src string, dest string) error {
+	contents, err := ioutil.ReadFile(src)
+	if err != nil {
+		return fmt.Errorf("Failed to read %s: %v", src, err)
+	}
+	if err := ioutil.WriteFile(dest, contents, 0644); err != nil {
+		return fmt.Errorf("Failed to write to %s: %v", dest, err)
+	}
+	return nil
+}

--- a/python/replicate/daemon.py
+++ b/python/replicate/daemon.py
@@ -78,7 +78,7 @@ def is_status_detail(x):
 
 
 class Daemon:
-    def __init__(self, project, socket_path=None):
+    def __init__(self, project, socket_path=None, debug=False):
         self.project = project
 
         if socket_path is None:
@@ -101,6 +101,8 @@ class Daemon:
             cmd += ["-R", self.project.repository]
         if self.project.directory:
             cmd += ["-D", self.project.directory]
+        if debug:
+            cmd += ["-v"]
         cmd.append(self.socket_path)
         self.process = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/python/replicate/project.py
+++ b/python/replicate/project.py
@@ -38,12 +38,16 @@ class Project:
     """
 
     def __init__(
-        self, repository: Optional[str] = None, directory: Optional[str] = None
+        self,
+        repository: Optional[str] = None,
+        directory: Optional[str] = None,
+        debug: bool = False,
     ):
         # Project is initialized on import, so don't do anything slow or anything that will raise an exception
         self.directory = directory
         self.repository = repository
         self._daemon_instance: Optional[Daemon] = None
+        self._debug = debug
 
     @property
     def experiments(self) -> ExperimentCollection:
@@ -51,7 +55,7 @@ class Project:
 
     def _daemon(self) -> Daemon:
         if self._daemon_instance is None:
-            self._daemon_instance = Daemon(self)
+            self._daemon_instance = Daemon(self, debug=self._debug)
         return self._daemon_instance
 
 
@@ -59,11 +63,12 @@ def init(
     path: Optional[str] = None,
     params: Optional[Dict[str, Any]] = None,
     disable_heartbeat: bool = False,
+    debug: bool = False,
 ) -> Experiment:
     """
     Create a new experiment.
     """
-    project = Project()
+    project = Project(debug=debug)
     return project.experiments.create(
         path=path, params=params, disable_heartbeat=disable_heartbeat
     )


### PR DESCRIPTION
This solves the bug where archive fails when files in the archive are written during archival.

Also adds a `debug` argument to `replicate.init()`, that enables verbose server logs.