### PR TITLE
Better checkout messages

### DIFF
--- a/go/pkg/project/checkout_test.go
+++ b/go/pkg/project/checkout_test.go
@@ -1,0 +1,50 @@
+package project
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/replicate/replicate/go/pkg/config"
+	"github.com/replicate/replicate/go/pkg/files"
+	"github.com/replicate/replicate/go/pkg/repository"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckoutWithNoPaths(t *testing.T) {
+	projectDir, err := files.TempDir("test-checkout")
+	require.NoError(t, err)
+	defer os.RemoveAll(projectDir)
+
+	repo, err := repository.NewDiskRepository(path.Join(projectDir, ".replicate"))
+	require.NoError(t, err)
+
+	fixedTime, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+	require.NoError(t, err)
+
+	experiment := &Experiment{
+		ID:      "1eeeeeeeee",
+		Created: fixedTime.Add(-10 * time.Minute),
+		Config:  &config.Config{},
+		Path:    "",
+		Checkpoints: []*Checkpoint{
+			{
+				ID:      "2ccccccccc",
+				Created: fixedTime.Add(-5 * time.Minute),
+				Path:    "",
+			},
+		},
+	}
+	require.NoError(t, experiment.Save(repo))
+
+	project := NewProject(repo, projectDir)
+
+	err = project.CheckoutCheckpoint(experiment.Checkpoints[0], experiment, projectDir, true)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Neither the checkpoint 2cccccc nor its experiment experiment 1eeeeee have any files associated with them.")
+
+	err = project.CheckoutCheckpoint(nil, experiment, projectDir, true)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "The experiment 1eeeeee does not have any files associated with it.")
+}

--- a/go/pkg/project/project.go
+++ b/go/pkg/project/project.go
@@ -244,7 +244,7 @@ func (p *Project) CreateExperiment(args CreateExperimentArgs, async bool, workCh
 
 	if exp.Path == "" {
 		if !quiet {
-			console.Info("Creating experiment %s", exp.ShortID())
+			console.Info("Creating experiment %s...", exp.ShortID())
 		}
 		return exp, nil
 	}
@@ -255,7 +255,7 @@ func (p *Project) CreateExperiment(args CreateExperimentArgs, async bool, workCh
 	}
 
 	if !quiet {
-		console.Info("Creating experiment %s, copying '%s' to '%s'...", exp.ShortID(), exp.Path, p.repository.RootURL())
+		console.Info("Creating experiment %s, copying '%s' to '%s' in the background...", exp.ShortID(), exp.Path, p.repository.RootURL())
 	}
 
 	work := func() error {
@@ -299,13 +299,13 @@ func (p *Project) CreateCheckpoint(args CreateCheckpointArgs, async bool, workCh
 	// the checkpoint without saving anything
 	if chk.Path == "" {
 		if !quiet {
-			console.Info("Creating checkpoint %s", chk.ShortID())
+			console.Info("Creating checkpoint %s...", chk.ShortID())
 		}
 		return chk, nil
 	}
 
 	if !quiet {
-		console.Info("Creating checkpoint %s, copying '%s' to '%s'...", chk.ShortID(), chk.Path, p.repository.RootURL())
+		console.Info("Creating checkpoint %s, copying '%s' to '%s' in the background...", chk.ShortID(), chk.Path, p.repository.RootURL())
 	}
 
 	tempDir, err := repository.CopyToTempDir(p.directory, chk.Path)


### PR DESCRIPTION
- Show messages before copying so it doesn't hang and look broken
- If no path has been passed, throw error.
- If path has been provided but no data exists, throw error.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>