### PR TITLE
Fix Python version

### DIFF
--- a/go/pkg/cli/show.go
+++ b/go/pkg/cli/show.go
@@ -183,9 +183,11 @@ func writeExperimentCommon(au aurora.Aurora, w *tabwriter.Writer, exp *project.E
 		fmt.Fprintf(w, "%s\t\n", au.Faint("(none)"))
 	}
 
-	fmt.Fprintf(w, "\t\n")
-	fmt.Fprintf(w, "%s\t\n", au.Bold("System"))
-	fmt.Fprintf(w, "Python version:\t%s\n", exp.PythonVersion)
+	if exp.PythonVersion != "" {
+		fmt.Fprintf(w, "\t\n")
+		fmt.Fprintf(w, "%s\t\n", au.Bold("System"))
+		fmt.Fprintf(w, "Python version:\t%s\n", exp.PythonVersion)
+	}
 
 	fmt.Fprintf(w, "\t\n")
 	fmt.Fprintf(w, "%s\t\n", au.Bold("Python Packages"))

--- a/go/pkg/project/project.go
+++ b/go/pkg/project/project.go
@@ -199,6 +199,7 @@ type CreateExperimentArgs struct {
 	Command        string
 	Params         map[string]param.Value
 	PythonPackages map[string]string
+	PythonVersion  string
 }
 
 func (p *Project) CreateExperiment(args CreateExperimentArgs, async bool, workChan chan func() error, quiet bool) (*Experiment, error) {
@@ -233,6 +234,7 @@ func (p *Project) CreateExperiment(args CreateExperimentArgs, async bool, workCh
 		Config:           conf,
 		Command:          args.Command,
 		Path:             args.Path,
+		PythonVersion:    args.PythonVersion,
 		PythonPackages:   args.PythonPackages,
 		ReplicateVersion: global.Version,
 	}

--- a/go/pkg/shared/serve.go
+++ b/go/pkg/shared/serve.go
@@ -40,6 +40,7 @@ func (s *server) CreateExperiment(ctx context.Context, req *servicepb.CreateExpe
 		Command:        pbReqExp.GetCommand(),
 		Params:         valueMapFromPb(pbReqExp.GetParams()),
 		PythonPackages: pbReqExp.GetPythonPackages(),
+		PythonVersion:  pbReqExp.GetPythonVersion(),
 	}
 	proj, err := s.getProject()
 	if err != nil {

--- a/python/tests/test_experiment.py
+++ b/python/tests/test_experiment.py
@@ -55,6 +55,15 @@ def test_init_and_checkpoint(temp_workdir):
         metadata = json.load(fh)
     assert metadata["id"] == experiment.id
     assert metadata["params"] == {"learning_rate": 0.002}
+    assert metadata["host"] == ""
+    assert metadata["user"] != ""
+    # FIXME: this is broken https://github.com/replicate/replicate/issues/492
+    assert metadata["config"]["repository"].startswith("file://")
+    assert metadata["command"] != ""
+    assert metadata["path"] == "."
+    assert metadata["python_version"] != ""
+    assert len(metadata["python_packages"]) > 0
+    assert metadata["replicate_version"] != ""
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with tarfile.open(experiment_tar_path) as tar:


### PR DESCRIPTION
There was an incomplete implementation in #485. It wasn't being passed through the stack correctly. Also added
some sanity tests for the Python -> Go -> Python round trip.

As an aside, there are so many places that new fields need to be added. I wonder if there is a way this can be simplified, or the test can be generalized to get the round trip always works.

`config` is also kind of broken, but low priority. #492 