### PR TITLE
Hide Python packages in show by default

### DIFF
--- a/go/pkg/cli/diff_test.go
+++ b/go/pkg/cli/diff_test.go
@@ -81,6 +81,11 @@ param-3:                  (not set)                      hi
 
 Python Packages
 foo:                      1.2.3                          (not set)
+foo2:                     1.2.3                          (not set)
+foo3:                     1.2.3                          (not set)
+foo4:                     1.2.3                          (not set)
+foo5:                     1.2.3                          (not set)
+tensorflow:               2.0.0                          (not set)
 
 Checkpoint
 ID:                       2cccccc                        4cccccc

--- a/go/pkg/cli/show_test.go
+++ b/go/pkg/cli/show_test.go
@@ -42,7 +42,7 @@ func createShowTestData(t *testing.T, workingDir string, conf *config.Config) re
 		User:           "andreas",
 		Config:         conf,
 		PythonVersion:  "3.4.5",
-		PythonPackages: map[string]string{"foo": "1.2.3"},
+		PythonPackages: map[string]string{"foo": "1.2.3", "foo2": "1.2.3", "foo3": "1.2.3", "foo4": "1.2.3", "foo5": "1.2.3", "tensorflow": "2.0.0"},
 		Checkpoints: []*project.Checkpoint{
 			{
 				ID:      "1ccccccccc",
@@ -133,7 +133,7 @@ func TestShowCheckpoint(t *testing.T) {
 
 	out := new(bytes.Buffer)
 	au := aurora.NewAurora(false)
-	err = showCheckpoint(au, out, proj, result.Experiment, result.Checkpoint)
+	err = showCheckpoint(au, out, proj, result.Experiment, result.Checkpoint, false)
 	require.NoError(t, err)
 	actual := out.String()
 
@@ -159,12 +159,13 @@ param-2:         hello
 System
 Python version:  3.4.5
 
-Python Packages
-foo:             1.2.3
+Python packages
+tensorflow:      2.0.0
+... and 5 more. Use --all to view.
 
 Metrics
-metric-1:        0.02 (primary, minimize)
-metric-2:        2
+metric-1:  0.02 (primary, minimize)
+metric-2:  2
 
 `
 	// remove initial newline
@@ -195,7 +196,7 @@ func TestShowExperiment(t *testing.T) {
 
 	out := new(bytes.Buffer)
 	au := aurora.NewAurora(false)
-	err = showExperiment(au, out, proj, result.Experiment)
+	err = showExperiment(au, out, proj, result.Experiment, false)
 	require.NoError(t, err)
 	actual := out.String()
 
@@ -215,8 +216,53 @@ param-2:         hello
 System
 Python version:  3.4.5
 
-Python Packages
+Python packages
+tensorflow:      2.0.0
+... and 5 more. Use --all to view.
+
+Checkpoints
+ID       STEP  CREATED     METRIC-1     METRIC-2
+1cccccc  10    2006-01-02  0.1          2
+2cccccc  20    2006-01-02  0.01 (best)  2
+3cccccc  20    2006-01-02  0.02         2
+
+To see more details about a checkpoint, run:
+  replicate show <checkpoint ID>
+`
+	// remove initial newline
+	expected = expected[1:]
+	actual = testutil.TrimRightLines(actual)
+	require.Equal(t, expected, actual)
+
+	// --all
+	out = new(bytes.Buffer)
+	err = showExperiment(au, out, proj, result.Experiment, true)
+	require.NoError(t, err)
+	actual = out.String()
+
+	expected = `
+Experiment: 1eeeeeeeee
+
+Created:         Mon, 02 Jan 2006 22:54:05 +08
+Status:          running
+Host:            10.1.1.1
+User:            andreas
+Command:         train.py --gamma=1.2 -x
+
+Params
+param-1:         100
+param-2:         hello
+
+System
+Python version:  3.4.5
+
+Python packages
 foo:             1.2.3
+foo2:            1.2.3
+foo3:            1.2.3
+foo4:            1.2.3
+foo5:            1.2.3
+tensorflow:      2.0.0
 
 Checkpoints
 ID       STEP  CREATED     METRIC-1     METRIC-2

--- a/go/pkg/slices/slices.go
+++ b/go/pkg/slices/slices.go
@@ -20,6 +20,16 @@ func ContainsAnyString(strings interface{}, query interface{}) bool {
 	return ContainsString(StringSlice(strings), query.(string))
 }
 
+// FilterString returns a copy of a slice with the items that return true when passed to `test`
+func FilterString(ss []string, test func(string) bool) (ret []string) {
+	for _, s := range ss {
+		if test(s) {
+			ret = append(ret, s)
+		}
+	}
+	return
+}
+
 // StringSlice converts an []interface{} slice to a []string slice
 func StringSlice(strings interface{}) []string {
 	if reflect.TypeOf(strings).Kind() != reflect.Slice {

--- a/web/pages/docs/reference/cli.mdx
+++ b/web/pages/docs/reference/cli.mdx
@@ -237,6 +237,7 @@ replicate show <experiment or checkpoint ID> [flags]
 ### Flags
 
 ```
+      --all                 Show all information
   -h, --help                help for show
       --json                Print output in JSON format
   -R, --repository string   Repository URL (e.g. 's3://my-replicate-bucket' (if omitted, uses repository URL from replicate.yaml)


### PR DESCRIPTION
Lots of Python packages make `replicate show` hard to use.

If there are interesting packages (tensorflow, torch, etc), show them. Otherwise, show at most 5. If `--all` is passed, show them all.

Looks a bit like this:

<img width="595" alt="Screen Shot 2021-01-13 at 19 27 34" src="https://user-images.githubusercontent.com/40906/104540967-725ca000-55d5-11eb-97c6-f8d338cd6768.png">

Any other ideas for "interesting" Python packages?