### PR TITLE
Display "fetching" before initing repository

### DIFF
--- a/go/pkg/cli/common.go
+++ b/go/pkg/cli/common.go
@@ -82,13 +82,20 @@ func getProjectDir() (string, error) {
 // getRepository returns the project's repository, with caching if needed
 // This is not in repository package so we can do user interface stuff around syncing
 func getRepository(repositoryURL, projectDir string) (repository.Repository, error) {
+	needsCaching, err := repository.NeedsCaching(repositoryURL)
+	if err != nil {
+		return nil, err
+	}
+	// Before repository initialization so this displays as quickly as possible
+	if needsCaching && projectDir != "" {
+		console.Info("Fetching new data from %q...", repositoryURL)
+	}
 	repo, err := repository.ForURL(repositoryURL, projectDir)
 	if err != nil {
 		return nil, err
 	}
 	// projectDir might be "" if you use --repository option
-	if repository.NeedsCaching(repo) && projectDir != "" {
-		console.Info("Fetching new data from %q...", repo.RootURL())
+	if needsCaching && projectDir != "" {
 		repo, err = repository.NewCachedMetadataRepository(projectDir, repo)
 		if err != nil {
 			return nil, err

--- a/go/pkg/repository/repository.go
+++ b/go/pkg/repository/repository.go
@@ -350,10 +350,10 @@ func extractTarItem(tarPath, itemPath, localPath string) error {
 	return nil
 }
 
-// NeedsCaching returns true if the repository is slow and needs caching
-func NeedsCaching(repo Repository) bool {
-	_, isDiskRepository := repo.(*DiskRepository)
-	return !isDiskRepository
+// NeedsCaching returns true if the repository URL is slow and needs caching
+func NeedsCaching(repositoryURL string) (bool, error) {
+	scheme, _, _, err := SplitURL(repositoryURL)
+	return scheme != "file", err
 }
 
 func unknownRepositoryScheme(scheme string) error {


### PR DESCRIPTION
Initializing the S3/GCS library takes some time, so display a log
message immediately. This makes running all replicate commands feel
much snappier.

Signed-off-by: Ben Firshman <ben@firshman.co.uk>